### PR TITLE
Fix Pytest4.x compatibility errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,7 @@ formats=bztar
 source-dir = rst
 build-dir  = doc
 
+[tool:pytest]
+markers =
+    no_ssl
+

--- a/test/test_dugong.py
+++ b/test/test_dugong.py
@@ -83,10 +83,17 @@ def pytest_generate_tests(metafunc):
     if not 'http_server' in metafunc.fixturenames:
         return
 
-    if getattr(metafunc.function, 'no_ssl', False):
-        params = ('plain',)
+    if hasattr(metafunc, 'definition'):
+        if metafunc.definition.get_closest_marker('no_ssl'):
+            params = ('plain',)
+        else:
+            params = ('plain', 'ssl')
     else:
-        params = ('plain', 'ssl')
+        # pytest < 3.6
+        if getattr(metafunc.function, 'no_ssl', False):
+            params = ('plain',)
+        else:
+            params = ('plain', 'ssl')
 
     metafunc.parametrize("http_server", params,
                          indirect=True, scope='module')


### PR DESCRIPTION
There are no longer named marker attributes:
https://github.com/pytest-dev/pytest/issues/891

This results in not expecting param `ssl` and leads to errors like:
```
...
test/test_dugong.py::test_http_proxy[plain-None] PASSED                  [  4%]
test/test_dugong.py::test_http_proxy[plain-8080] PASSED                  [  5%]
test/test_dugong.py::test_connect_proxy[plain-None] PASSED               [  6%]
test/test_dugong.py::test_connect_proxy[plain-8080] PASSED               [  7%]
...
test/test_dugong.py::test_http_proxy[ssl-None] FAILED                    [ 51%]
test/test_dugong.py::test_http_proxy[ssl-8080] FAILED                    [ 52%]
test/test_dugong.py::test_connect_proxy[ssl-None] FAILED                 [ 53%]
test/test_dugong.py::test_connect_proxy[ssl-8080] FAILED                 [ 54%]
...

So, the marker `no_ssl` is just ignored.
Let's use the `get_closest_marker` method instead.