### PR TITLE
Use select instead of poll when poll is unavailable (e.g., on Win32).

### DIFF
--- a/rst/coroutines.rst
+++ b/rst/coroutines.rst
@@ -36,11 +36,12 @@ operation can be carried out without blocking.
 The `PollNeeded` instance contains information about the I/O request
 that the coroutine would like to perform. The `~PollNeeded.fd`
 attribute is a file descriptor, and the `~PollNeeded.mask` attribute
-is an :ref:`epoll <epoll-objects>` compatible event mask. Therefore, a
+is an :ref:`poll <poll-objects>` compatible event mask. Therefore, a
 very simple way to wait for a coroutine to complete is to use a
 `~select.select` loop::
 
-  from select import select, POLLIN
+  from select import select
+  from dugong import POLLIN, POLLOUT
 
   # establish connection, send request, read response header
 

--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -15,9 +15,8 @@ if __name__ == '__main__':
     sys.exit(pytest.main([__file__] + sys.argv[1:]))
 
 import socket
-from select import POLLIN
 import logging
-from dugong import PollNeeded
+from dugong import PollNeeded, POLLIN
 
 try:
     import asyncio


### PR DESCRIPTION
Continue to use poll when it is available, to avoid "filedescriptor out
of range in select()" errors. (Win32's select takes a list of handles,
not a bit vector, so this error can't occur.)

With this change, dugong appears to work fine on Windows in my limited
testing. Without this change, it crashes on the import of POLLIN and
POLLOUT.

Clients of dugong that import and use the POLLIN and POLLOUT constants
explicitly will still fail on Windows. The fix is to import them from
dugong instead of select. It would be better to use other constants
(such as 'r' and 'w') but that would break API compatibility.