### PR TITLE
Preventing Runtime Error caused by "Event loop is closed"

### DIFF
--- a/test/test_aio.py
+++ b/test/test_aio.py
@@ -48,6 +48,7 @@ def write(sock):
         sock.send(buf)
 
 def test_aio_future():
+    asyncio.set_event_loop(asyncio.new_event_loop())
     loop = asyncio.get_event_loop()
     try:
         (sock1, sock2) = socket.socketpair()


### PR DESCRIPTION
 This PR aims to improve test reliability by initializing `loop` before executing `asyncio.get_event_loop()` by calling method `asyncio.set_event_loop` and `asyncio.new_event_loop` in order to prevent Runtime Error caused by "Event loop is closed".

```
test_aio.py:49 (test_aio_future)
Traceback (most recent call last):
  File ".../test_aio.py", line 73, in test_aio_future
    asyncio.Task(write(sock2))
  File "/usr/lib/python3.8/asyncio/base_events.py", line 719, in call_soon
    self._check_closed()
  File "/usr/lib/python3.8/asyncio/base_events.py", line 508, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed